### PR TITLE
fix the broken javascript admin resources with S3Boto on Django 1.4

### DIFF
--- a/s3_folder_storage/s3.py
+++ b/s3_folder_storage/s3.py
@@ -5,7 +5,18 @@
 from storages.backends.s3boto import S3BotoStorage
 from django.conf import settings
 
-class StaticStorage(S3BotoStorage):
+class FixedS3BotoStorage(S3BotoStorage):
+    """
+    fix the broken javascript admin resources with S3Boto on Django 1.4
+    for more info see http://code.larlet.fr/django-storages/issue/121/s3boto-admin-prefix-issue-with-django-14
+    """
+    def url(self, name):
+        url = super(FixedS3BotoStorage, self).url(name)
+        if name.endswith('/') and not url.endswith('/'):
+            url += '/'
+        return url
+
+class StaticStorage(FixedS3BotoStorage):
     """
     Storage for static files.
     The folder is defined in settings.STATIC_S3_PATH
@@ -15,7 +26,7 @@ class StaticStorage(S3BotoStorage):
         kwargs['location'] = settings.STATIC_S3_PATH
         super(StaticStorage, self).__init__(*args, **kwargs)
 
-class DefaultStorage(S3BotoStorage):
+class DefaultStorage(FixedS3BotoStorage):
     """
     Storage for uploaded media files.
     The folder is defined in settings.DEFAULT_S3_PATH


### PR DESCRIPTION
fix the broken javascript admin resources with S3Boto on Django 1.4

for more info see http://code.larlet.fr/django-storages/issue/121/s3boto-admin-prefix-issue-with-django-14
